### PR TITLE
feat(config): support loading config from cwd

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,8 +72,8 @@ func Read(p string) Config {
 		return DefaultConfig
 	}
 
-	c.Output = path.Join(path.Dir(p), c.Output)
-	c.Font = path.Join(path.Dir(p), c.Font)
+	c.Output = path.Join(path.Dir(c.Path), c.Output)
+	c.Font = path.Join(path.Dir(c.Path), c.Font)
 
 	return c
 }


### PR DESCRIPTION
This allow to double-click the file instead of running it from the terminal, and it should load the config in its directory.

Fix #9