### PR TITLE
feat: fail when no config is found

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@
 
 - Write a `config.yaml` file
 
-  See [config.yaml](./examples/config.yaml) for an example.
+  See [config.yaml](./examples/config.yaml) for an example, the available
+  options are and documentation.
 
 - Put `seshat` in the same directory as the `config.yaml` file.
 

--- a/cmd/seshat/main.go
+++ b/cmd/seshat/main.go
@@ -22,7 +22,11 @@ func main() {
 	configPtr := flag.String("config", "config.yaml", "path to the configuration file")
 	flag.Parse()
 
-	config := config.Read(*configPtr)
+	config, err := config.Read(*configPtr)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
 
 	if err := run(config); err != nil {
 		fmt.Printf("error: %v\n", err)

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,19 +1,24 @@
-font: ./fonts/Fira-Sans
-output: ./output.pdf
+# `font` is the folder containing the fonts to test.
+font: fonts/Fira-Sans
+
+# `output` is the path to the output PDF.
+output: output.pdf
 
 rules:
+  # `text` writes the given text in each available font.
   - type: text
     features: "sups"
     args:
       - "testing 3.14 ff ll ii 0O"
-  - type: alphabet
-  - type: grid
-    args:
-      - 01a
+
+  # `grid` create a grid of all available characters in each available font.
   - type: grid
     features: "zero, smcp"
     args:
       - 01a
-  - type: text
-    args:
-      - "Hello, world!"
+
+  # `alphabet` writes the alphabet in each available font.
+  - type: alphabet
+
+  # `lorem` writes a paragraph of lorem ipsum text in each available font.
+  - type: lorem


### PR DESCRIPTION
Running without a configuration now fails, instead of using default values.

It also ensures all the paths are absolutes.

Fix #14