### PR TITLE
feat(config): set defaults and propagate values to all rules

### DIFF
--- a/cmd/seshat/main.go
+++ b/cmd/seshat/main.go
@@ -109,7 +109,8 @@ func render(c config.Config) error {
 	}
 	defer f.Close()
 
-	pdf := pdf.New(f, c.Width, c.Height, &pdf.Options{
+	// TODO: allow to create a pdf without the first page
+	pdf := pdf.New(f, c.Defaults.Width, c.Defaults.Height, &pdf.Options{
 		SubsetFonts: true,
 	})
 

--- a/config.yaml
+++ b/config.yaml
@@ -5,14 +5,24 @@ font: examples/fonts/Fira-Sans
 # `output` is the path to the output PDF.
 output: examples/output.pdf
 
-# `width` is the width of the output PDF in mm.
-width: 210
+# `defaults` is a dictionary of default values for the rules.
+# Each rule can override these values in their args.
+defaults:
+  # `width` is the width of the output PDF in mm.
+  width: 210
 
-# `height` is the height of the output PDF in mm.
-height: 297
+  # `height` is the height of the output PDF in mm.
+  height: 297
 
-# `size` is the default size of the text in pt.
-size: 30
+  # `size` is the size of the text in pt.
+  size: 30
+
+  # `features` is a comma-separated list of OpenType features.
+  features: # no default value, see examples.
+
+  # `columns` is the number of columns in the grid.
+  # It pertains only to the `grid` rule.
+  columns: 3
 
 # `rules` is a list of rules to apply to the output PDF.
 rules:
@@ -21,14 +31,9 @@ rules:
   - type: text
 
     # `args` is a dictionary of arguments to pass to the rule.
+    # They can override the default values defined above.
     args:
-
-      # `features` is a comma-separated list of OpenType features.
-      # Default: none
       features: zero, smcp
-
-      # `size` is the size of the text in this rule in pt.
-      # It overrides the default size.
       size: 40
 
     # `inputs` is a list of strings to write in the PDF.
@@ -39,16 +44,6 @@ rules:
   # `grid` create a grid of all available characters in each available font.
   # It will scale down the text to fit the grid in the PDF.
   - type: grid
-    args:
-
-      # `columns` is the number of columns in the grid.
-      # Default: 3
-      columns: 3
-
-      # Other available args:
-      # features
-      # size
-
     # `inputs` is a list of strings to write as a grid in the PDF.
     # Each string is written in each available font.
     inputs:
@@ -80,7 +75,8 @@ rules:
 
   - type: grid
     args:
-      columns: 3
+      size: 100
+      columns: 2
       features: smcp, subs
     inputs:
       - 012

--- a/config.yaml
+++ b/config.yaml
@@ -31,7 +31,7 @@ rules:
   - type: text
 
     # `args` is a dictionary of arguments to pass to the rule.
-    # They can override the default values defined above.
+    # They override the default values defined above.
     args:
       features: zero, smcp
       size: 40

--- a/internal/testers/grid/grid.go
+++ b/internal/testers/grid/grid.go
@@ -1,9 +1,7 @@
 package grid
 
 import (
-	"fmt"
 	"math"
-	"strconv"
 
 	"github.com/nobe4/seshat/internal/config"
 	"github.com/nobe4/seshat/internal/font"
@@ -20,16 +18,7 @@ type Box struct {
 func Test(pdf *pdf.PDF, fonts font.Fonts, config config.Config, rule config.Rule) {
 	width, height := pdf.Size()
 
-	// TODO: move this into the config package
-	columnsString, ok := rule.Args["columns"]
-	if !ok {
-		columnsString = "3"
-	}
-	columns, err := strconv.Atoi(columnsString)
-	if err != nil {
-		fmt.Printf("Error parsing columns: %v\n", err)
-		columns = 3
-	}
+	columns := rule.Args.Columns
 
 	gridSize := biggestGridSize(len(fonts))
 	boxes := []Box{}
@@ -37,20 +26,10 @@ func Test(pdf *pdf.PDF, fonts font.Fonts, config config.Config, rule config.Rule
 
 	// TODO: do a binary search
 	// Find the smallest font size that fits the text in the grid.
-	// TODO: move this in the config parsing
-	size := config.Size
-	sizeString, ok := rule.Args["size"]
-	if ok {
-		var err error
-		size, err = strconv.ParseFloat(sizeString, 64)
-		if err != nil {
-			size = config.Size
-			fmt.Printf("error parsing size: %v\n", err)
-		}
-	}
+	size := rule.Args.Size
 
 	for {
-		boxes, maxW, maxH = prepareBoxes(size, fonts, rule.Args["features"], rule.Inputs)
+		boxes, maxW, maxH = prepareBoxes(size, fonts, rule.Args.Features, rule.Inputs)
 
 		if float64(columns)*maxW*float64(gridSize) > width-10 {
 			size -= 1

--- a/internal/testers/text/text.go
+++ b/internal/testers/text/text.go
@@ -1,9 +1,6 @@
 package text
 
 import (
-	"fmt"
-	"strconv"
-
 	"github.com/nobe4/seshat/internal/config"
 	"github.com/nobe4/seshat/internal/font"
 	"github.com/tdewolff/canvas"
@@ -19,21 +16,8 @@ func Test(pdf *pdf.PDF, fonts font.Fonts, config config.Config, rule config.Rule
 
 	for _, input := range rule.Inputs {
 		for _, font := range fonts {
-			// TODO: move this in the config parsing
-			size := config.Size
-			sizeString, ok := rule.Args["size"]
-			if ok {
-				var err error
-				size, err = strconv.ParseFloat(sizeString, 64)
-				if err != nil {
-					size = config.Size
-					fmt.Printf("error parsing size: %v\n", err)
-				}
-			}
-
-			face := font.Font.Face(size, canvas.Black)
-			// TODO: move features in config parsing
-			face.Font.SetFeatures(rule.Args["features"])
+			face := font.Font.Face(rule.Args.Size, canvas.Black)
+			face.Font.SetFeatures(rule.Args.Features)
 
 			txt := canvas.NewTextBox(face, input, width, 0.0, canvas.Left, canvas.Top, 0.0, 0.0)
 


### PR DESCRIPTION
This allows for easier configuration of the various arguments, and parses the values in typed fields, which simplifies their usage.

Fix #29