### PR TITLE
fix(config): use `normal` default features

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,9 @@ defaults:
   size: 30
 
   # `features` is a comma-separated list of OpenType features.
-  features: # no default value, see examples.
+  # Use `normal` to disable all features.
+  # See https://en.wikipedia.org/wiki/List_of_typographic_features
+  features: normal
 
   # `columns` is the number of columns in the grid.
   # It pertains only to the `grid` rule.
@@ -47,6 +49,7 @@ rules:
     # `inputs` is a list of strings to write as a grid in the PDF.
     # Each string is written in each available font.
     inputs:
+      - 0
       - a
       - b
       - c

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,8 +148,6 @@ func (r *Rule) PropagateDefaults(defaults Args) {
 		r.Args.Size = defaults.Size
 	}
 
-	// TODO: this won't catch the case where the user wants to remove the
-	// default features
 	if r.Args.Features == "" {
 		r.Args.Features = defaults.Features
 	}


### PR DESCRIPTION
This works as a default value that also doesn't impact the font.