### PR TITLE
fix(config): use custom tag to reset features

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,9 +18,9 @@ defaults:
   size: 30
 
   # `features` is a comma-separated list of OpenType features.
-  # Use `normal` to disable all features.
+  # Use `none` to disable all features.
   # See https://en.wikipedia.org/wiki/List_of_typographic_features
-  features: normal
+  features: none
 
   # `columns` is the number of columns in the grid.
   # It pertains only to the `grid` rule.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -149,7 +149,11 @@ func (r *Rule) PropagateDefaults(defaults Args) {
 	}
 
 	if r.Args.Features == "" {
-		r.Args.Features = defaults.Features
+		if defaults.Features != "none" {
+			r.Args.Features = defaults.Features
+		}
+	} else if r.Args.Features == "none" {
+		r.Args.Features = ""
 	}
 
 	if r.Args.Columns == 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,10 +148,8 @@ func (r *Rule) PropagateDefaults(defaults Args) {
 		r.Args.Size = defaults.Size
 	}
 
-	if r.Args.Features == "" {
-		if defaults.Features != "none" {
-			r.Args.Features = defaults.Features
-		}
+	if r.Args.Features == "" && defaults.Features != "none" {
+		r.Args.Features = defaults.Features
 	} else if r.Args.Features == "none" {
 		r.Args.Features = ""
 	}


### PR DESCRIPTION
`normal` is invalid and failed with

    error parsing feature 'normal': invalid tag length

Using `none` is clearer and the custom logic ensures it behaves accordingly.

cc https://github.com/nobe4/seshat/pull/33